### PR TITLE
chore: bump minimum node version to v25.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "url": "https://github.com/ExampleWasTakenStudios/horizon/issues"
     },
     "engines": {
-        "node": "24.x.x"
+        "node": "^25.2.1"
     },
     "homepage": "https://github.com/ExampleWasTakenStudios/horizon#readme",
     "devDependencies": {


### PR DESCRIPTION
This bumps the minimum NodeJS version listed in the engines field of package.json to `^25.2.1`.