### PR TITLE
feat: query context pattern

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -31,9 +51,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
 name = "horizon"
 version = "26.1.0-beta.1"
 dependencies = [
+ "dashmap",
  "tokio",
 ]
 
@@ -62,6 +89,12 @@ dependencies = [
  "wasi",
  "windows-sys",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "parking_lot"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,4 +4,5 @@ version = "26.1.0-beta.1"
 edition = "2024"
 
 [dependencies]
+dashmap = "6.2.1"
 tokio = { version = "1.52.3", features = ["full"] }

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -14,7 +14,7 @@ impl Default for PacketBuffer {
 /// Represents a cursored buffer with length 512.
 /// It features special methods to read the buffer that keep track of the cursor i.e. the current location in the buffer.
 impl PacketBuffer {
-    pub fn new() -> Self {
+    fn new() -> Self {
         PacketBuffer {
             buffer: [0; 512],
             position: 0,
@@ -78,5 +78,34 @@ impl PacketBuffer {
         }
 
         Ok(subarray)
+    }
+
+    pub fn write_u8(&mut self, value: u8) -> Result<(), ResponseCode> {
+        if self.position + 1 > self.buffer.len() {
+            return Err(ResponseCode::SERVFAIL);
+        }
+
+        self.buffer[self.position] = value;
+        self.position += 1;
+
+        Ok(())
+    }
+
+    pub fn write_u16(&mut self, value: u16) -> Result<(), ResponseCode> {
+        let bytes = value.to_be_bytes();
+        for byte in bytes {
+            self.write_u8(byte)?;
+        }
+
+        Ok(())
+    }
+
+    pub fn write_u32(&mut self, value: u32) -> Result<(), ResponseCode> {
+        let bytes = value.to_be_bytes();
+        for byte in bytes {
+            self.write_u8(byte)?;
+        }
+
+        Ok(())
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,0 +1,31 @@
+use std::{net::SocketAddr, sync::Arc, time};
+
+use dashmap::DashMap;
+use tokio::net;
+
+use crate::{buffer::PacketBuffer, protocol::{DnsPacket, ResponseCode}};
+
+pub struct QueryContext {
+    udp_socket: Arc<net::UdpSocket>,
+    original_id: u16,
+    horizon_id: u16,
+    source_addr: SocketAddr,
+    received_timestamp: time::SystemTime,
+    id_map: Arc<DashMap<u16, QueryContext>>,
+    packet: DnsPacket,
+}
+
+impl QueryContext {
+    pub fn create(udp_socket: Arc<net::UdpSocket>, source_addr: SocketAddr, buffer: [u8; 512], tx_id_map: u8) -> Self {
+        let packet_buffer = PacketBuffer::from_raw_buffer(buffer);
+        let packet_parsing_result = DnsPacket::parse_from(&mut packet_buffer);
+
+        
+    }
+}
+
+impl Drop for QueryContext {
+    fn drop(&mut self) {
+        self.id_map.remove(&self.horizon_id);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
-use std::io::Write;
 use tokio::{self, net, runtime};
 
 pub mod protocol;
+pub mod context;
 pub mod buffer;
 
 pub fn entry() {
@@ -14,11 +14,11 @@ pub fn entry() {
 
     rt.block_on(async {
         let socket = net::UdpSocket::bind("0.0.0.0:1234").await.unwrap();
-        println!("Bound to socket: {:?}", socket);
+        println!("Bound to socket: {:?}", socket.local_addr());
         let mut buffer: [u8; 512] = [0; 512];
 
         loop {
-             let (bytes, source) = match socket.recv_from(&mut buffer).await {
+             let (_, source) = match socket.recv_from(&mut buffer).await {
                 Ok(result) => result,
                 Err(e) => {
                     eprintln!("Failure while receiving datagram...should send a SERVFAIL response code.\n{:#?}", e);
@@ -28,17 +28,7 @@ pub fn entry() {
 
              tokio::spawn(async move {
                 let mut buffer = buffer::PacketBuffer::from_raw_buffer(buffer);
-                let packet = protocol::DnsPacket::parse_from(&mut buffer).unwrap();
-
-                println!("Received {} bytes from {} in packet: {:#?}", bytes, source, packet);
-                let labels = &packet.questions[0].name.labels;
-
-                println!("Query:");
-                let mut stdout = std::io::stdout();
-                for label in labels {
-                    stdout.write_all(label).unwrap();
-                    stdout.flush().unwrap();
-                }
+                let packet = protocol::DnsPacket::parse_from(&mut buffer);
 
              });
         }

--- a/src/protocol/domain.rs
+++ b/src/protocol/domain.rs
@@ -1,3 +1,5 @@
+use tokio::io::AsyncWriteExt;
+
 use crate::{buffer::PacketBuffer, protocol::ResponseCode};
 
 #[derive(Debug)]
@@ -87,5 +89,16 @@ impl DomainName {
         buffer.advance_by(bytes_consumed);
 
         Ok(DomainName { labels })
+    }
+
+    pub fn to_vec(&self) -> Vec<u8> {
+        let mut buffer: Vec<u8> = Vec::new();
+
+        for label in &self.labels {
+            buffer.write_u8(label.len() as u8);
+            tokio::io::AsyncWriteExt::write_all(&mut buffer, label);
+        }
+
+        buffer
     }
 }

--- a/src/protocol/domain.rs
+++ b/src/protocol/domain.rs
@@ -1,5 +1,3 @@
-use tokio::io::AsyncWriteExt;
-
 use crate::{buffer::PacketBuffer, protocol::ResponseCode};
 
 #[derive(Debug)]
@@ -91,14 +89,19 @@ impl DomainName {
         Ok(DomainName { labels })
     }
 
-    pub fn to_vec(&self) -> Vec<u8> {
-        let mut buffer: Vec<u8> = Vec::new();
+    /// TODO: This method currently does not support message compression.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let total_capacity = self.labels.iter().map(|label| label.len() + 1).sum::<usize>();
+
+        let mut bytes: Vec<u8> = Vec::with_capacity(total_capacity);
 
         for label in &self.labels {
-            buffer.write_u8(label.len() as u8);
-            tokio::io::AsyncWriteExt::write_all(&mut buffer, label);
+            // DNS RFC restricts label lengths to 63 so we can cast to u8 here
+            bytes.push(label.len() as u8);
+
+            bytes.extend_from_slice(&label);
         }
 
-        buffer
+        bytes
     }
 }

--- a/src/protocol/enums.rs
+++ b/src/protocol/enums.rs
@@ -1,4 +1,4 @@
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub enum ResponseCode {
     NOERROR = 0,
     FORMERR = 1,

--- a/src/protocol/header.rs
+++ b/src/protocol/header.rs
@@ -1,3 +1,5 @@
+use tokio::io::AsyncWriteExt;
+
 use crate::{buffer::PacketBuffer, protocol::enums::ResponseCode};
 
 #[derive(Debug)]
@@ -54,5 +56,39 @@ impl DnsHeader {
             authoritative_count,
             additional_count,
         })
+    }
+
+    pub fn to_vec(&self) -> Vec<u8> {
+        let mut buffer: Vec<u8> = Vec::with_capacity(12);
+
+        // --- ID ---
+        buffer.write_u16(self.id);
+
+        // --- Flags ---
+        let mut flags: u16 = 0;
+        flags |= (self.is_response as u16) << 15;
+        flags |= (self.op_code as u16 & 0b1111) << 11;
+        flags |= (self.is_authoritative as u16) << 10;
+        flags |= (self.is_truncated as u16) << 9;
+        flags |= (self.is_recursion_desired as u16) << 8;
+        flags |= (self.is_recursion_avail as u16) << 7;
+        flags |= (self.z as u16 & 0b111) << 6;
+        flags |= self.response_code as u16 & 0b1111;
+
+        buffer.write_u16(flags);
+
+        // --- Question Count ---
+        buffer.write_u16(self.question_count);
+
+        // --- Answers Count ---
+        buffer.write_u16(self.answer_count);
+
+        // --- Authoritative Count ---
+        buffer.write_u16(self.authoritative_count);
+
+        // --- Additionals Count ---
+        buffer.write_u16(self.additional_count);
+
+        buffer
     }
 }

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -4,6 +4,7 @@ pub mod header;
 pub mod packet;
 pub mod records;
 pub mod string;
+pub mod question;
 
 pub use domain::*;
 pub use enums::*;
@@ -11,3 +12,4 @@ pub use header::*;
 pub use packet::*;
 pub use records::*;
 pub use string::*;
+pub use question::*;

--- a/src/protocol/packet.rs
+++ b/src/protocol/packet.rs
@@ -1,4 +1,7 @@
-use crate::{buffer::PacketBuffer, protocol::{DnsHeader, DnsQuestion, DnsRecord, ResponseCode}};
+use crate::{
+    buffer::PacketBuffer,
+    protocol::{DnsHeader, DnsQuestion, DnsRecord, ResponseCode},
+};
 
 #[derive(Debug)]
 pub struct DnsPacket {
@@ -10,6 +13,22 @@ pub struct DnsPacket {
 }
 
 impl DnsPacket {
+    pub fn create(
+        header: DnsHeader,
+        questions: Option<Vec<DnsQuestion>>,
+        answers: Option<Vec<DnsRecord>>,
+        authoritatives: Option<Vec<DnsRecord>>,
+        additionals: Option<Vec<DnsRecord>>,
+    ) -> DnsPacket {
+        DnsPacket {
+            header,
+            questions: questions.unwrap_or(Vec::with_capacity(0)),
+            answers: answers.unwrap_or(Vec::with_capacity(0)),
+            authoritatives: authoritatives.unwrap_or(Vec::with_capacity(0)),
+            additionals: additionals.unwrap_or(Vec::with_capacity(0)),
+        }
+    }
+
     pub fn parse_from(buffer: &mut PacketBuffer) -> Result<Self, ResponseCode> {
         let header = DnsHeader::read_from(buffer)?;
         let mut questions: Vec<DnsQuestion> = Vec::with_capacity(header.question_count as usize);
@@ -45,5 +64,19 @@ impl DnsPacket {
             authoritatives,
             additionals,
         })
+    }
+
+    pub fn to_vec(&self) -> [u8; 512] {
+        let buffer: Vec<u8> = Vec::with_capacity(12);
+
+        buffer.extend(self.header.to_vec());
+
+        for question in self.questions {
+            buffer.extend(question.to_vec());
+        }
+
+        for answer in self.answers {
+            buffer.extend(answer)
+        }
     }
 }

--- a/src/protocol/question.rs
+++ b/src/protocol/question.rs
@@ -1,0 +1,33 @@
+use tokio::io::AsyncWriteExt;
+
+use crate::{buffer::PacketBuffer, protocol::{DnsClass, DnsType, DomainName, ResponseCode}};
+
+#[derive(Debug)]
+pub struct DnsQuestion {
+    pub name: DomainName,
+    pub query_type: DnsType,
+    pub query_class: DnsClass,
+}
+
+impl DnsQuestion {
+    pub fn read_from(buffer: &mut PacketBuffer) -> Result<Self, ResponseCode> {
+        let q_name = DomainName::read_from(buffer)?;
+        let q_type = DnsType::from_number(buffer.read_u16()?);
+        let q_class = DnsClass::from_number(buffer.read_u16()?);
+
+        Ok(DnsQuestion {
+            name: q_name,
+            query_type: q_type,
+            query_class: q_class,
+        })
+    }
+
+    pub fn to_vec(&self) -> Vec<u8> {
+        let mut buffer: Vec<u8> = Vec::new();
+        buffer.write_all(&self.name.to_vec());
+        buffer.write_u16(self.query_type.to_number());
+        buffer.write_u16(self.query_class.to_number());
+
+        buffer
+    }
+}

--- a/src/protocol/records.rs
+++ b/src/protocol/records.rs
@@ -1,3 +1,5 @@
+use tokio::io::AsyncWriteExt;
+
 use crate::{
     buffer::PacketBuffer,
     protocol::{
@@ -23,6 +25,11 @@ impl AData {
             ],
         })
     }
+
+    pub fn to_vec(&self) -> Vec<u8> {
+        let buffer: Vec<u8> = self.address.to_vec();
+        buffer
+    }
 }
 
 #[derive(Debug)]
@@ -36,6 +43,10 @@ impl NsData {
             ns_domain_name: DomainName::read_from(buffer)?,
         })
     }
+
+    pub fn to_vec(&self) -> Vec<u8> {
+        self.ns_domain_name.to_vec()
+    }
 }
 
 #[derive(Debug)]
@@ -48,6 +59,10 @@ impl CNameData {
         Ok(CNameData {
             c_name: DomainName::read_from(buffer)?,
         })
+    }
+
+    pub fn to_vec(&self) -> Vec<u8> {
+        self.c_name.to_vec()
     }
 }
 
@@ -82,6 +97,13 @@ impl SoaRecordData {
             minimum,
         })
     }
+
+    pub fn to_vec(&self) -> Vec<u8> {
+        let mut buffer: Vec<u8> = Vec::new();
+
+        buffer.write_all(&self.m_name.to_vec());
+        buffer
+    }
 }
 
 #[derive(Debug)]
@@ -94,6 +116,13 @@ impl PtrData {
         Ok(PtrData {
             ptr_d_name: DomainName::read_from(buffer)?,
         })
+    }
+
+    pub fn to_vec(&self) -> Vec<u8> {
+        let mut buffer: Vec<u8> = Vec::new();
+
+        buffer.write_all(&self.ptr_d_name.to_vec());
+        buffer
     }
 }
 
@@ -113,6 +142,14 @@ impl MxRecordData {
             exchange,
         })
     }
+
+    pub fn to_vec(&self) -> Vec<u8> {
+        let mut buffer: Vec<u8> = Vec::new();
+
+        buffer.write_u16(self.preference);
+        buffer.write_all(&self.exchange.to_vec());
+        buffer
+    }
 }
 
 #[derive(Debug)]
@@ -125,6 +162,10 @@ impl TxtData {
         Ok(TxtData {
             txt_data: CharString::read_from(buffer, rd_length)?,
         })
+    }
+
+    pub fn to_vec(&self) -> Vec<u8> {
+        self.txt_data.to_vec().clone().to_vec()
     }
 }
 
@@ -147,27 +188,6 @@ pub enum DnsRecordData {
     MX(MxRecordData),
     TXT(TxtData),
     UNKNOWN(UnknownRData),
-}
-
-#[derive(Debug)]
-pub struct DnsQuestion {
-    pub name: DomainName,
-    pub query_type: DnsType,
-    pub query_class: DnsClass,
-}
-
-impl DnsQuestion {
-    pub fn read_from(buffer: &mut PacketBuffer) -> Result<Self, ResponseCode> {
-        let q_name = DomainName::read_from(buffer)?;
-        let q_type = DnsType::from_number(buffer.read_u16()?);
-        let q_class = DnsClass::from_number(buffer.read_u16()?);
-
-        Ok(DnsQuestion {
-            name: q_name,
-            query_type: q_type,
-            query_class: q_class,
-        })
-    }
 }
 
 #[derive(Debug)]
@@ -208,5 +228,11 @@ impl DnsRecord {
             rd_length,
             r_data,
         })
+    }
+
+    pub fn to_vec(&self) -> Vec<u8> {
+        match self.r#type {
+            
+        }
     }
 }

--- a/src/protocol/records.rs
+++ b/src/protocol/records.rs
@@ -26,9 +26,12 @@ impl AData {
         })
     }
 
-    pub fn to_vec(&self) -> Vec<u8> {
-        let buffer: Vec<u8> = self.address.to_vec();
-        buffer
+    pub fn write_to(&self, buffer: &mut PacketBuffer) -> Result<(), ResponseCode> {
+        for byte in self.address {
+            buffer.write_u8(byte)?;
+        }
+
+        Ok(())
     }
 }
 
@@ -44,8 +47,14 @@ impl NsData {
         })
     }
 
-    pub fn to_vec(&self) -> Vec<u8> {
-        self.ns_domain_name.to_vec()
+    pub fn write_to(&self, buffer: &mut PacketBuffer) -> Result<(), ResponseCode> {
+        let bytes = self.ns_domain_name.to_bytes();
+
+        for byte in bytes {
+            buffer.write_u8(byte)?;
+        }
+
+        Ok(())
     }
 }
 
@@ -61,8 +70,14 @@ impl CNameData {
         })
     }
 
-    pub fn to_vec(&self) -> Vec<u8> {
-        self.c_name.to_vec()
+    pub fn write_to(&self, buffer: &mut PacketBuffer) -> Result<(), ResponseCode> {
+        let bytes = self.c_name.to_bytes();
+
+        for byte in bytes {
+            buffer.write_u8(byte)?;
+        }
+
+        Ok(())
     }
 }
 
@@ -98,11 +113,25 @@ impl SoaRecordData {
         })
     }
 
-    pub fn to_vec(&self) -> Vec<u8> {
-        let mut buffer: Vec<u8> = Vec::new();
+    pub fn write_to(&self, buffer: &mut PacketBuffer) -> Result<(), ResponseCode> {
+        let m_name_bytes = self.m_name.to_bytes();
+        let r_name_bytes = self.r_name.to_bytes();
 
-        buffer.write_all(&self.m_name.to_vec());
-        buffer
+        for byte in m_name_bytes {
+            buffer.write_u8(byte)?;
+        }
+
+        for byte in r_name_bytes {
+            buffer.write_u8(byte)?;
+        }
+
+        buffer.write_u32(self.serial)?;
+        buffer.write_u32(self.refresh)?;
+        buffer.write_u32(self.retry)?;
+        buffer.write_u32(self.expire)?;
+        buffer.write_u32(self.minimum)?;
+
+        Ok(())
     }
 }
 
@@ -118,11 +147,12 @@ impl PtrData {
         })
     }
 
-    pub fn to_vec(&self) -> Vec<u8> {
-        let mut buffer: Vec<u8> = Vec::new();
+    pub fn write_to(&self, buffer: &mut PacketBuffer) -> Result<(), ResponseCode> {
+        for byte in self.ptr_d_name.to_bytes() {
+            buffer.write_u8(byte)?;
+        }
 
-        buffer.write_all(&self.ptr_d_name.to_vec());
-        buffer
+        Ok(())
     }
 }
 
@@ -143,12 +173,14 @@ impl MxRecordData {
         })
     }
 
-    pub fn to_vec(&self) -> Vec<u8> {
-        let mut buffer: Vec<u8> = Vec::new();
+    pub fn write_to(&self, buffer: &mut PacketBuffer) -> Result<(), ResponseCode> {
+        buffer.write_u16(self.preference)?;
 
-        buffer.write_u16(self.preference);
-        buffer.write_all(&self.exchange.to_vec());
-        buffer
+        for byte in self.exchange.to_bytes() {
+            buffer.write_u8(byte)?;
+        }
+
+        Ok(())
     }
 }
 
@@ -164,8 +196,12 @@ impl TxtData {
         })
     }
 
-    pub fn to_vec(&self) -> Vec<u8> {
-        self.txt_data.to_vec().clone().to_vec()
+    pub fn write_to(&self, buffer: &mut PacketBuffer) -> Result<(), ResponseCode> {
+        for byte in self.txt_data.to_bytes() {
+            buffer.write_u8(byte)?;
+        }
+
+        Ok(())
     }
 }
 
@@ -175,6 +211,14 @@ pub struct UnknownRData(Vec<u8>);
 impl UnknownRData {
     pub fn read_from(buffer: &mut PacketBuffer, rd_length: usize) -> Result<Self, ResponseCode> {
         Ok(UnknownRData(buffer.read_subarray(rd_length)?))
+    }
+
+    pub fn write_to(&self, buffer: &mut PacketBuffer) -> Result<(), ResponseCode> {
+        for byte in self.0 {
+            buffer.write_u8(byte)?;
+        }
+
+        Ok(())
     }
 }
 
@@ -188,6 +232,21 @@ pub enum DnsRecordData {
     MX(MxRecordData),
     TXT(TxtData),
     UNKNOWN(UnknownRData),
+}
+
+impl DnsRecordData {
+    pub fn write_to(&self, buffer: &mut PacketBuffer) -> Result<(), ResponseCode> {
+        match self {
+            DnsRecordData::A(data) => data.write_to(buffer),
+            DnsRecordData::NS(data) => data.write_to(buffer),
+            DnsRecordData::CNAME(data) => data.write_to(buffer),
+            DnsRecordData::SOA(data) => data.write_to(buffer),
+            DnsRecordData::PTR(data) => data.write_to(buffer),
+            DnsRecordData::MX(data) => data.write_to(buffer),
+            DnsRecordData::TXT(data) => data.write_to(buffer),
+            DnsRecordData::UNKNOWN(data) => data.write_to(buffer),
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -230,9 +289,21 @@ impl DnsRecord {
         })
     }
 
-    pub fn to_vec(&self) -> Vec<u8> {
-        match self.r#type {
-            
+    pub fn write_to(&self, buffer: &mut PacketBuffer) -> Result<(), ResponseCode> {
+        for byte in self.name.to_bytes() {
+            buffer.write_u8(byte)?;
         }
+
+        buffer.write_u16(self.r#type.to_number())?;
+        buffer.write_u16(self.class.to_number())?;
+        buffer.write_u32(self.ttl)?;
+        buffer.write_u16(self.rd_length)?;
+
+        for byte in self.r_data.
+
+        /*
+            Instead of writing directly do the buffer in the corresponding methods of RDATA,
+            we should turn them into bytes and write them to a buffer in a method of the DnsPacket impl
+         */
     }
 }

--- a/src/protocol/string.rs
+++ b/src/protocol/string.rs
@@ -23,7 +23,7 @@ impl CharString {
         Ok(CharString { buffer: string })
     }
 
-    pub fn to_vec(&self) -> Vec<u8> {
+    pub fn to_bytes(&self) -> Vec<u8> {
         self.buffer.clone()
     }
 }

--- a/src/protocol/string.rs
+++ b/src/protocol/string.rs
@@ -23,7 +23,7 @@ impl CharString {
         Ok(CharString { buffer: string })
     }
 
-    pub fn as_buffer(&self) -> &[u8] {
-        &self.buffer
+    pub fn to_vec(&self) -> Vec<u8> {
+        self.buffer.clone()
     }
 }


### PR DESCRIPTION
To keep a singular centralized data structure that maintains the state of a query throughout its journey through Horizon, this PR introduces the context pattern.

It works by creating a context for every query that enters Horizon's system.

In the future, this is where the query can either be resolved locally by querying the local zone file, recursively resolving it or simply forwarding it to another DNS service (stub resolver functionality).