### PR TITLE
feat: translate DnsPacket to bytes

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -29,7 +29,7 @@ impl<const T: usize> PacketBuffer<T> {
         }
     }
 
-    pub fn as_slice(&self) -> &[u8; T] {
+    pub fn to_slice(&self) -> &[u8; T] {
         &self.buffer
     }
 
@@ -105,7 +105,6 @@ impl<const T: usize> PacketBuffer<T> {
     ///
     /// Returns the length written, or an error message as `&str`
     pub fn write_u16(&mut self, value: u16) -> Result<usize, &str> {
-
         let buf = [((value & 0xFF00) >> 8) as u8, (value & 0x00FF) as u8];
 
         let mut v = self
@@ -137,9 +136,7 @@ impl<const T: usize> PacketBuffer<T> {
             .get_mut(self.position..=(self.position + 2))
             .ok_or("Index out of bounds.")?;
         match v.write(&buf) {
-            Err(_) => {
-                Err("Could not write u32 value to PacketBuffer.")
-            }
+            Err(_) => Err("Could not write u32 value to PacketBuffer."),
             Ok(length) => {
                 self.position += length;
                 Ok(length)

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -81,7 +81,10 @@ impl<const T: usize> PacketBuffer<T> {
         Ok(subarray)
     }
 
-    pub fn write_u8(&mut self, value: u8) -> Result<(), &str> {
+    /// Write a `u8` to the buffer.
+    ///
+    /// Returns the length written, or an error message as `&str`
+    pub fn write_u8(&mut self, value: u8) -> Result<usize, &str> {
         let v = self
             .buffer
             .get_mut(self.position)
@@ -90,10 +93,13 @@ impl<const T: usize> PacketBuffer<T> {
 
         self.position += 1;
 
-        Ok(())
+        Ok(1_usize)
     }
 
-    pub fn write_u16(&mut self, value: u16) -> Result<(), &str> {
+    /// Write a `u8` to the buffer.
+    ///
+    /// Returns the length written, or an error message as `&str`
+    pub fn write_u16(&mut self, value: u16) -> Result<usize, &str> {
         let buf = [(value & 0xFF00) as u8, (value & 0x00FF) as u8];
 
         let mut v = self
@@ -104,13 +110,17 @@ impl<const T: usize> PacketBuffer<T> {
             Err(_) => {
                 return Err("Could not write u16 value to PacketBuffer.");
             }
-            Ok(length) => self.position += length,
+            Ok(length) => {
+                self.position += length;
+                return Ok(length);
+            }
         };
-
-        Ok(())
     }
 
-    pub fn write_u32(&mut self, value: u32) -> Result<(), &str> {
+    /// Write a `u8` to the buffer.
+    ///
+    /// Returns the length written, or an error message as `&str`
+    pub fn write_u32(&mut self, value: u32) -> Result<usize, &str> {
         let buf = [
             (value & 0xFF0000) as u8,
             (value & 0x00FF00) as u8,
@@ -125,9 +135,10 @@ impl<const T: usize> PacketBuffer<T> {
             Err(_) => {
                 return Err("Could not write u32 value to PacketBuffer.");
             }
-            Ok(length) => self.position += length,
+            Ok(length) => {
+                self.position += length;
+                return Ok(length);
+            }
         };
-
-        Ok(())
     }
 }

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -146,7 +146,7 @@ impl<const T: usize> PacketBuffer<T> {
     ///
     /// Returns the length written, or an error message as `&str`.
     pub fn write_subarray(&mut self, array: &[u8]) -> Result<usize, &str> {
-        let mut v = self.buffer.get_mut(self.position..=(self.position + array.len())).ok_or("Index out of bounds.")?;
+        let mut v = self.buffer.get_mut(self.position..(self.position + array.len())).ok_or("Index out of bounds.")?;
         match v.write(&array) {
             Err(_) => return Err("Could not write array to PacketBuffer."),
             Ok(length) => {

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -141,4 +141,18 @@ impl<const T: usize> PacketBuffer<T> {
             }
         };
     }
+
+    /// Write a &[u8] to the buffer.
+    ///
+    /// Returns the length written, or an error message as `&str`.
+    pub fn write_subarray(&mut self, array: &[u8]) -> Result<usize, &str> {
+        let mut v = self.buffer.get_mut(self.position..=(self.position + array.len())).ok_or("Index out of bounds.")?;
+        match v.write(&array) {
+            Err(_) => return Err("Could not write array to PacketBuffer."),
+            Ok(length) => {
+                self.position += length;
+                return Ok(length);
+            }
+        }
+    }
 }

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -8,7 +8,7 @@ pub struct PacketBuffer<const T: usize> {
     position: usize,
 }
 
-impl Default for PacketBuffer<1232> {
+impl<const T: usize> Default for PacketBuffer<T> {
     fn default() -> Self {
         Self::new()
     }
@@ -42,18 +42,23 @@ impl<const T: usize> PacketBuffer<T> {
     }
 
     pub fn read_u8(&mut self) -> Result<u8, ResponseCode> {
-        if self.position >= 512 {
+        if self.position >= T {
             return Err(ResponseCode::FORMERR);
         }
 
-        let value = self.buffer[self.position];
+        let value = match self.buffer.get(self.position) {
+            None => {
+                return Err(ResponseCode::FORMERR);
+            }
+            Some(v) => *v,
+        };
         self.position += 1;
 
         Ok(value)
     }
 
     pub fn read_u16(&mut self) -> Result<u16, ResponseCode> {
-        let value = ((self.read_u8()? as u16) << 8) | (self.read_u8()? as u16);
+        let value = ((self.read_u8()? as u16) << 8) | (self.read_u8()? as u16) & 0x00FF;
 
         Ok(value)
     }
@@ -70,7 +75,7 @@ impl<const T: usize> PacketBuffer<T> {
     pub fn read_subarray(&mut self, length: usize) -> Result<Vec<u8>, ResponseCode> {
         let mut subarray: Vec<u8> = Vec::new();
 
-        if length > self.buffer.len() {
+        if self.position + length > self.buffer.len() {
             return Err(ResponseCode::FORMERR);
         }
 
@@ -84,12 +89,12 @@ impl<const T: usize> PacketBuffer<T> {
     /// Write a `u8` to the buffer.
     ///
     /// Returns the length written, or an error message as `&str`
-    pub fn write_u8(&mut self, value: &u8) -> Result<usize, &str> {
+    pub fn write_u8(&mut self, value: u8) -> Result<usize, &str> {
         let v = self
             .buffer
             .get_mut(self.position)
             .ok_or("Index out of bounds.")?;
-        *v = *value;
+        *v = value;
 
         self.position += 1;
 
@@ -99,32 +104,32 @@ impl<const T: usize> PacketBuffer<T> {
     /// Write a `u8` to the buffer.
     ///
     /// Returns the length written, or an error message as `&str`
-    pub fn write_u16(&mut self, value: &u16) -> Result<usize, &str> {
-        let buf = [(value & 0xFF00) as u8, (value & 0x00FF) as u8];
+    pub fn write_u16(&mut self, value: u16) -> Result<usize, &str> {
+
+        let buf = [((value & 0xFF00) >> 8) as u8, (value & 0x00FF) as u8];
 
         let mut v = self
             .buffer
             .get_mut(self.position..=(self.position + 1))
             .ok_or("Index out of bounds.")?;
         match v.write(&buf) {
-            Err(_) => {
-                return Err("Could not write u16 value to PacketBuffer.");
-            }
+            Err(_) => Err("Could not write u16 value to PacketBuffer."),
             Ok(length) => {
                 self.position += length;
-                return Ok(length);
+                Ok(length)
             }
-        };
+        }
     }
 
     /// Write a `u8` to the buffer.
     ///
     /// Returns the length written, or an error message as `&str`
-    pub fn write_u32(&mut self, value: &u32) -> Result<usize, &str> {
+    pub fn write_u32(&mut self, value: u32) -> Result<usize, &str> {
         let buf = [
-            (value & 0xFF0000) as u8,
-            (value & 0x00FF00) as u8,
-            (value & 0x0000FF) as u8,
+            ((value & 0xFF_00_00_00) >> 24) as u8,
+            ((value & 0x00_FF_00_00) >> 16) as u8,
+            ((value & 0x00_00_FF_00) >> 8) as u8,
+            (value & 0x00_00_00_FF) as u8,
         ];
 
         let mut v = self
@@ -133,25 +138,28 @@ impl<const T: usize> PacketBuffer<T> {
             .ok_or("Index out of bounds.")?;
         match v.write(&buf) {
             Err(_) => {
-                return Err("Could not write u32 value to PacketBuffer.");
+                Err("Could not write u32 value to PacketBuffer.")
             }
             Ok(length) => {
                 self.position += length;
-                return Ok(length);
+                Ok(length)
             }
-        };
+        }
     }
 
     /// Write a &[u8] to the buffer.
     ///
     /// Returns the length written, or an error message as `&str`.
     pub fn write_subarray(&mut self, array: &[u8]) -> Result<usize, &str> {
-        let mut v = self.buffer.get_mut(self.position..(self.position + array.len())).ok_or("Index out of bounds.")?;
-        match v.write(&array) {
-            Err(_) => return Err("Could not write array to PacketBuffer."),
+        let mut v = self
+            .buffer
+            .get_mut(self.position..(self.position + array.len()))
+            .ok_or("Index out of bounds.")?;
+        match v.write(array) {
+            Err(_) => Err("Could not write array to PacketBuffer."),
             Ok(length) => {
                 self.position += length;
-                return Ok(length);
+                Ok(length)
             }
         }
     }

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,5 +1,8 @@
+use std::io::Write;
+
 use crate::protocol::ResponseCode;
 
+/// A cursored buffer with length `T`.
 pub struct PacketBuffer<const T: usize> {
     buffer: [u8; T],
     position: usize,
@@ -11,8 +14,6 @@ impl Default for PacketBuffer<1232> {
     }
 }
 
-/// Represents a cursored buffer with length 512.
-/// It features special methods to read the buffer that keep track of the cursor i.e. the current location in the buffer.
 impl<const T: usize> PacketBuffer<T> {
     pub fn new() -> Self {
         PacketBuffer {
@@ -78,5 +79,55 @@ impl<const T: usize> PacketBuffer<T> {
         }
 
         Ok(subarray)
+    }
+
+    pub fn write_u8(&mut self, value: u8) -> Result<(), &str> {
+        let v = self
+            .buffer
+            .get_mut(self.position)
+            .ok_or("Index out of bounds.")?;
+        *v = value;
+
+        self.position += 1;
+
+        Ok(())
+    }
+
+    pub fn write_u16(&mut self, value: u16) -> Result<(), &str> {
+        let buf = [(value & 0xFF00) as u8, (value & 0x00FF) as u8];
+
+        let mut v = self
+            .buffer
+            .get_mut(self.position..=(self.position + 1))
+            .ok_or("Index out of bounds.")?;
+        match v.write(&buf) {
+            Err(_) => {
+                return Err("Could not write u16 value to PacketBuffer.");
+            }
+            Ok(length) => self.position += length,
+        };
+
+        Ok(())
+    }
+
+    pub fn write_u32(&mut self, value: u32) -> Result<(), &str> {
+        let buf = [
+            (value & 0xFF0000) as u8,
+            (value & 0x00FF00) as u8,
+            (value & 0x0000FF) as u8,
+        ];
+
+        let mut v = self
+            .buffer
+            .get_mut(self.position..=(self.position + 2))
+            .ok_or("Index out of bounds.")?;
+        match v.write(&buf) {
+            Err(_) => {
+                return Err("Could not write u32 value to PacketBuffer.");
+            }
+            Ok(length) => self.position += length,
+        };
+
+        Ok(())
     }
 }

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -84,12 +84,12 @@ impl<const T: usize> PacketBuffer<T> {
     /// Write a `u8` to the buffer.
     ///
     /// Returns the length written, or an error message as `&str`
-    pub fn write_u8(&mut self, value: u8) -> Result<usize, &str> {
+    pub fn write_u8(&mut self, value: &u8) -> Result<usize, &str> {
         let v = self
             .buffer
             .get_mut(self.position)
             .ok_or("Index out of bounds.")?;
-        *v = value;
+        *v = *value;
 
         self.position += 1;
 
@@ -99,7 +99,7 @@ impl<const T: usize> PacketBuffer<T> {
     /// Write a `u8` to the buffer.
     ///
     /// Returns the length written, or an error message as `&str`
-    pub fn write_u16(&mut self, value: u16) -> Result<usize, &str> {
+    pub fn write_u16(&mut self, value: &u16) -> Result<usize, &str> {
         let buf = [(value & 0xFF00) as u8, (value & 0x00FF) as u8];
 
         let mut v = self
@@ -120,7 +120,7 @@ impl<const T: usize> PacketBuffer<T> {
     /// Write a `u8` to the buffer.
     ///
     /// Returns the length written, or an error message as `&str`
-    pub fn write_u32(&mut self, value: u32) -> Result<usize, &str> {
+    pub fn write_u32(&mut self, value: &u32) -> Result<usize, &str> {
         let buf = [
             (value & 0xFF0000) as u8,
             (value & 0x00FF00) as u8,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-use std::net::Ipv4Addr;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
 use crate::systems::{DecisionPipelineSystem, IngressEgressSystem, StubResolverSystem};
 use tokio::runtime;
@@ -12,7 +12,7 @@ mod systems;
 pub const OWN_IP_SOCKET_ADDR: &str = "0.0.0.0:1234";
 pub const MAX_PACKET_SIZE: usize = 512;
 
-pub const UPSTREAM_IP_ADDR: Ipv4Addr = Ipv4Addr::from_octets([1, 1, 1, 1]);
+pub const UPSTREAM_IP_ADDR: IpAddr = IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1));
 
 pub fn entry() {
     let rt = runtime::Builder::new_multi_thread()
@@ -49,8 +49,6 @@ pub fn entry() {
         let ies_join_set = ies.run().await;
         let dps_join_set = dps.run().await;
         let srs_join_set = srs.run().await;
-
-        println!("READY");
 
         ies_join_set.join_all().await;
         dps_join_set.join_all().await;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,8 +9,10 @@ mod protocol;
 mod query_state;
 mod systems;
 
-pub const IP_ADDR: &str = "0.0.0.0:1234";
-pub const MAX_PACKET_SIZE: usize = 1232;
+pub const OWN_IP_SOCKET_ADDR: &str = "0.0.0.0:1234";
+pub const MAX_PACKET_SIZE: usize = 512;
+
+pub const UPSTREAM_IP_ADDR: Ipv4Addr = Ipv4Addr::from_octets([1, 1, 1, 1]);
 
 pub fn entry() {
     let rt = runtime::Builder::new_multi_thread()
@@ -26,7 +28,7 @@ pub fn entry() {
 
         // Init IES
         let ies = IngressEgressSystem::new(
-            Ipv4Addr::new(1, 1, 1, 1),
+            UPSTREAM_IP_ADDR,
             channels.ies_to_dps.tx.clone(),
             channels.ies_answer.rx,
             channels.ies_upstream_resolve.rx,
@@ -34,14 +36,21 @@ pub fn entry() {
         .await;
 
         // Init DPS
-        let dps = DecisionPipelineSystem::new(channels.ies_to_dps.rx, channels.dps_to_srs.tx.clone());
+        let dps =
+            DecisionPipelineSystem::new(channels.ies_to_dps.rx, channels.dps_to_srs.tx.clone());
 
         // Init SRS
-        let srs = StubResolverSystem::new(channels.dps_to_srs.rx, channels.ies_upstream_resolve.tx.clone(), channels.ies_answer.tx.clone());
+        let srs = StubResolverSystem::new(
+            channels.dps_to_srs.rx,
+            channels.ies_upstream_resolve.tx.clone(),
+            channels.ies_answer.tx.clone(),
+        );
 
         let ies_join_set = ies.run().await;
         let dps_join_set = dps.run().await;
         let srs_join_set = srs.run().await;
+
+        println!("READY");
 
         ies_join_set.join_all().await;
         dps_join_set.join_all().await;

--- a/src/protocol/domain.rs
+++ b/src/protocol/domain.rs
@@ -96,7 +96,7 @@ impl DomainName {
 
         for label in label_slice {
             for char_byte in label {
-                length_written = buffer.write_u8(char_byte)?;
+                length_written = buffer.write_u8(*char_byte)?;
             }
         }
 

--- a/src/protocol/domain.rs
+++ b/src/protocol/domain.rs
@@ -88,4 +88,18 @@ impl DomainName {
 
         Ok(DomainName { labels })
     }
+
+    pub fn to_bytes<const T: usize>(&self, buffer: &mut PacketBuffer<T>) -> Result<usize, String> {
+        let label_slice = self.labels.get(0..self.labels.len()).ok_or("Index out of bounds while trying to access labels.")?;
+
+        let mut length_written = 0_usize;
+
+        for label in label_slice {
+            for char_byte in label {
+                length_written = buffer.write_u8(char_byte)?;
+            }
+        }
+
+        Ok(length_written)
+    }
 }

--- a/src/protocol/domain.rs
+++ b/src/protocol/domain.rs
@@ -82,7 +82,7 @@ impl DomainName {
     }
 
     pub fn read_from<const T: usize>(buffer: &mut PacketBuffer<T>) -> Result<Self, ResponseCode> {
-        let (labels, bytes_consumed) = Self::parse_raw(buffer.as_slice(), buffer.get_position())?;
+        let (labels, bytes_consumed) = Self::parse_raw(buffer.to_slice(), buffer.get_position())?;
 
         buffer.advance_by(bytes_consumed);
 
@@ -90,7 +90,10 @@ impl DomainName {
     }
 
     pub fn to_bytes<const T: usize>(&self, buffer: &mut PacketBuffer<T>) -> Result<usize, String> {
-        let label_slice = self.labels.get(0..self.labels.len()).ok_or("Index out of bounds while trying to access labels.")?;
+        let label_slice = self
+            .labels
+            .get(0..self.labels.len())
+            .ok_or("Index out of bounds while trying to access labels.")?;
 
         let mut length_written = 0_usize;
 

--- a/src/protocol/enums.rs
+++ b/src/protocol/enums.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub enum ResponseCode {
     NOERROR = 0,
     FORMERR = 1,
@@ -18,6 +18,17 @@ impl ResponseCode {
             4 => ResponseCode::NOTIMP,
             5 => ResponseCode::REFUSED,
             0 | _ => ResponseCode::NOERROR,
+        }
+    }
+
+    pub fn to_number(&self) -> u8 {
+        match *self {
+            ResponseCode::NOERROR => 0,
+            ResponseCode::FORMERR => 1,
+            ResponseCode::SERVFAIL => 2,
+            ResponseCode::NXDOMAIN => 3,
+            ResponseCode::NOTIMP => 4,
+            ResponseCode::REFUSED => 5,
         }
     }
 }

--- a/src/protocol/enums.rs
+++ b/src/protocol/enums.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum ResponseCode {
     NOERROR = 0,
     FORMERR = 1,

--- a/src/protocol/header.rs
+++ b/src/protocol/header.rs
@@ -66,7 +66,9 @@ impl DnsHeader {
 
         let mut length_written = buffer.write_u16(self.id)?;
 
-        length_written += buffer.write_u16(self.flags_to_bitfield())?;
+        let flags = self.flags_to_bitfield();
+
+        length_written += buffer.write_u16(flags)?;
 
         length_written += buffer.write_u16(self.question_count)?;
         length_written += buffer.write_u16(self.answer_count)?;
@@ -77,22 +79,17 @@ impl DnsHeader {
     }
 
     fn flags_to_bitfield(&self) -> u16 {
-        let is_response = (self.is_response as u16) << 15;
-        let op_code = ((self.op_code as u16) & 0x0F) << 11;
-        let is_authoritative = (self.is_authoritative as u16) << 10;
-        let is_truncated = (self.is_truncated as u16) << 9;
-        let is_recursion_desired = (self.is_recursion_desired as u16) << 8;
-        let is_recursion_avail = (self.is_recursion_avail as u16) << 7;
-        let z = ((self.z as u16) & 0x07) << 4;
-        let response_code = (self.response_code as u16) & 0x0F;
+        let mut flags = 0_u16;
 
-        (is_response
-            | op_code
-            | is_authoritative
-            | is_truncated
-            | is_recursion_desired
-            | is_recursion_avail
-            | z
-            | response_code).to_be()
+        flags |= (self.is_response as u16) << 15;
+        flags |= ((self.op_code & 0x0F) as u16) << 11;
+        flags |= (self.is_authoritative as u16) << 10;
+        flags |= (self.is_truncated as u16) << 9;
+        flags |= (self.is_recursion_desired as u16) << 8;
+        flags |= (self.is_recursion_avail as u16) << 7;
+        flags |= ((self.z & 0x07) as u16) << 4;
+        flags |= (self.response_code.to_number() & 0x0F) as u16;
+
+        flags
     }
 }

--- a/src/protocol/header.rs
+++ b/src/protocol/header.rs
@@ -58,29 +58,41 @@ impl DnsHeader {
 
     pub fn to_bytes<const T: usize>(&self, buffer: &mut PacketBuffer<T>) -> Result<usize, String> {
         if buffer.get_position() != 0 {
-            return Err(format!(
+            return Err(
                 "PacketBuffer position must be 0 at the beginning of header translation"
-            ));
+                    .to_string(),
+            );
         }
 
-        let mut length_written = buffer.write_u16(&self.id)?;
+        let mut length_written = buffer.write_u16(self.id)?;
 
-        let mut flags: u16 = self.id as u16
-            | self.is_response as u16
-            | self.op_code as u16
-            | self.is_authoritative as u16
-            | self.is_truncated as u16
-            | self.is_recursion_desired as u16
-            | self.is_recursion_avail as u16
-            | self.z as u16
-            | self.response_code as u16;
-        length_written += buffer.write_u16(&flags)?;
+        length_written += buffer.write_u16(self.flags_to_bitfield())?;
 
-        length_written += buffer.write_u16(&self.question_count)?;
-        length_written += buffer.write_u16(&self.answer_count)?;
-        length_written += buffer.write_u16(&self.authoritative_count)?;
-        length_written += buffer.write_u16(&self.additional_count)?;
+        length_written += buffer.write_u16(self.question_count)?;
+        length_written += buffer.write_u16(self.answer_count)?;
+        length_written += buffer.write_u16(self.authoritative_count)?;
+        length_written += buffer.write_u16(self.additional_count)?;
 
         Ok(length_written)
+    }
+
+    fn flags_to_bitfield(&self) -> u16 {
+        let is_response = (self.is_response as u16) << 15;
+        let op_code = ((self.op_code as u16) & 0x0F) << 11;
+        let is_authoritative = (self.is_authoritative as u16) << 10;
+        let is_truncated = (self.is_truncated as u16) << 9;
+        let is_recursion_desired = (self.is_recursion_desired as u16) << 8;
+        let is_recursion_avail = (self.is_recursion_avail as u16) << 7;
+        let z = ((self.z as u16) & 0x07) << 4;
+        let response_code = (self.response_code as u16) & 0x0F;
+
+        (is_response
+            | op_code
+            | is_authoritative
+            | is_truncated
+            | is_recursion_desired
+            | is_recursion_avail
+            | z
+            | response_code).to_be()
     }
 }

--- a/src/protocol/header.rs
+++ b/src/protocol/header.rs
@@ -55,4 +55,32 @@ impl DnsHeader {
             additional_count,
         })
     }
+
+    pub fn to_bytes<const T: usize>(&self, buffer: &mut PacketBuffer<T>) -> Result<usize, String> {
+        if buffer.get_position() != 0 {
+            return Err(format!(
+                "PacketBuffer position must be 0 at the beginning of header translation"
+            ));
+        }
+
+        let mut length_written = buffer.write_u16(&self.id)?;
+
+        let mut flags: u16 = self.id as u16
+            | self.is_response as u16
+            | self.op_code as u16
+            | self.is_authoritative as u16
+            | self.is_truncated as u16
+            | self.is_recursion_desired as u16
+            | self.is_recursion_avail as u16
+            | self.z as u16
+            | self.response_code as u16;
+        length_written += buffer.write_u16(&flags)?;
+
+        length_written += buffer.write_u16(&self.question_count)?;
+        length_written += buffer.write_u16(&self.answer_count)?;
+        length_written += buffer.write_u16(&self.authoritative_count)?;
+        length_written += buffer.write_u16(&self.additional_count)?;
+
+        Ok(length_written)
+    }
 }

--- a/src/protocol/packet.rs
+++ b/src/protocol/packet.rs
@@ -1,4 +1,7 @@
-use crate::{MAX_PACKET_SIZE, buffer::PacketBuffer, protocol::{DnsHeader, DnsQuestion, DnsRecord, ResponseCode}};
+use crate::{
+    buffer::PacketBuffer,
+    protocol::{DnsHeader, DnsQuestion, DnsRecord, ResponseCode},
+};
 
 #[derive(Debug, Clone)]
 pub struct DnsPacket {
@@ -47,7 +50,36 @@ impl DnsPacket {
         })
     }
 
-    pub fn to_raw_bytes(&self) -> Option<[u8; MAX_PACKET_SIZE]> {
-        None // TODO: impl.
+    pub fn to_bytes<const T: usize>(&self, buffer: &mut PacketBuffer<T>) -> Result<usize, String> {
+        if buffer.get_position() != 0 {
+            return Err("Attempted to translate packet into non-empty buffer.".into());
+        }
+
+        let mut length_written = self.header.to_bytes(buffer)?;
+
+        // Safety check since a DNS header must always be 12 bytes long
+        if length_written != 12 {
+            return Err(format!(
+                "Header should be 12 bytes but was {length_written}"
+            ));
+        }
+
+        for question in &self.questions {
+            length_written += question.to_bytes(buffer)?;
+        }
+
+        for answer in &self.answers {
+            length_written += answer.to_bytes(buffer)?;
+        }
+
+        for authoritative in &self.authoritatives {
+            length_written += authoritative.to_bytes(buffer)?;
+        }
+
+        for additional in &self.additionals {
+            length_written += additional.to_bytes(buffer)?;
+        }
+
+        Ok(length_written)
     }
 }

--- a/src/protocol/packet.rs
+++ b/src/protocol/packet.rs
@@ -82,4 +82,20 @@ impl DnsPacket {
 
         Ok(length_written)
     }
+
+    pub fn new(
+        header: DnsHeader,
+        questions: Vec<DnsQuestion>,
+        answers: Vec<DnsRecord>,
+        authoritatives: Vec<DnsRecord>,
+        additionals: Vec<DnsRecord>,
+    ) -> Self {
+        Self {
+            header,
+            questions,
+            answers,
+            authoritatives,
+            additionals,
+        }
+    }
 }

--- a/src/protocol/records.rs
+++ b/src/protocol/records.rs
@@ -82,6 +82,18 @@ impl SoaRecordData {
             minimum,
         })
     }
+
+    pub fn to_bytes<const T: usize>(&self, buffer: &mut PacketBuffer<T>) -> Result<usize, String> {
+        let mut length_written = self.m_name.to_bytes(buffer)?;
+        length_written += self.r_name.to_bytes(buffer)?;
+        length_written += buffer.write_u32(&self.serial)?;
+        length_written += buffer.write_u32(&self.refresh)?;
+        length_written += buffer.write_u32(&self.retry)?;
+        length_written += buffer.write_u32(&self.expire)?;
+        length_written += buffer.write_u32(&self.minimum)?;
+
+        Ok(length_written)
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -113,6 +125,13 @@ impl MxRecordData {
             exchange,
         })
     }
+
+    pub fn to_bytes<const T: usize>(&self, buffer: &mut PacketBuffer<T>) -> Result<usize, String> {
+        let mut length_written = buffer.write_u16(&self.preference)?;
+        length_written += self.exchange.to_bytes(buffer)?;
+
+        Ok(length_written)
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -121,7 +140,10 @@ pub struct TxtData {
 }
 
 impl TxtData {
-    pub fn read_from<const T: usize>(buffer: &mut PacketBuffer<T>, rd_length: u16) -> Result<Self, ResponseCode> {
+    pub fn read_from<const T: usize>(
+        buffer: &mut PacketBuffer<T>,
+        rd_length: u16,
+    ) -> Result<Self, ResponseCode> {
         Ok(TxtData {
             txt_data: CharString::read_from(buffer, rd_length)?,
         })
@@ -132,7 +154,10 @@ impl TxtData {
 pub struct UnknownRData(Vec<u8>);
 
 impl UnknownRData {
-    pub fn read_from<const T: usize>(buffer: &mut PacketBuffer<T>, rd_length: usize) -> Result<Self, ResponseCode> {
+    pub fn read_from<const T: usize>(
+        buffer: &mut PacketBuffer<T>,
+        rd_length: usize,
+    ) -> Result<Self, ResponseCode> {
         Ok(UnknownRData(buffer.read_subarray(rd_length)?))
     }
 }
@@ -147,6 +172,21 @@ pub enum DnsRecordData {
     MX(MxRecordData),
     TXT(TxtData),
     UNKNOWN(UnknownRData),
+}
+
+impl DnsRecordData {
+    pub fn to_bytes<const T: usize>(&self, buffer: &mut PacketBuffer<T>) -> Result<usize, String> {
+        match self {
+            DnsRecordData::A(d) => return Ok(buffer.write_subarray(&d.address)?),
+            DnsRecordData::NS(d) => return Ok(d.ns_domain_name.to_bytes(buffer)?),
+            DnsRecordData::CNAME(d) => return Ok(d.c_name.to_bytes(buffer)?),
+            DnsRecordData::SOA(d) => return Ok(d.to_bytes(buffer)?),
+            DnsRecordData::PTR(d) => return Ok(d.ptr_d_name.to_bytes(buffer)?),
+            DnsRecordData::MX(d) => return Ok(d.to_bytes(buffer)?),
+            DnsRecordData::TXT(d) => return Ok(d.txt_data.to_bytes(buffer)?),
+            DnsRecordData::UNKNOWN(d) => return Ok(buffer.write_subarray(&d.0)?),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -167,6 +207,14 @@ impl DnsQuestion {
             query_type: q_type,
             query_class: q_class,
         })
+    }
+
+    pub fn to_bytes<const T: usize>(&self, buffer: &mut PacketBuffer<T>) -> Result<usize, String> {
+        let mut length_written = self.name.to_bytes(buffer)?;
+        length_written += buffer.write_u16(&self.query_type.to_number())?;
+        length_written += buffer.write_u16(&self.query_class.to_number())?;
+
+        Ok(length_written)
     }
 }
 
@@ -208,5 +256,17 @@ impl DnsRecord {
             rd_length,
             r_data,
         })
+    }
+
+    pub fn to_bytes<const T: usize>(&self, buffer: &mut PacketBuffer<T>) -> Result<usize, String> {
+        let mut length_written = self.name.to_bytes(buffer)?;
+
+        length_written += buffer.write_u16(&self.r#type.to_number())?;
+        length_written += buffer.write_u16(&self.class.to_number())?;
+        length_written += buffer.write_u32(&self.ttl)?;
+        length_written += buffer.write_u16(&self.rd_length)?;
+        length_written += self.r_data.to_bytes(buffer)?;
+
+        Ok(length_written)
     }
 }

--- a/src/protocol/records.rs
+++ b/src/protocol/records.rs
@@ -86,11 +86,11 @@ impl SoaRecordData {
     pub fn to_bytes<const T: usize>(&self, buffer: &mut PacketBuffer<T>) -> Result<usize, String> {
         let mut length_written = self.m_name.to_bytes(buffer)?;
         length_written += self.r_name.to_bytes(buffer)?;
-        length_written += buffer.write_u32(&self.serial)?;
-        length_written += buffer.write_u32(&self.refresh)?;
-        length_written += buffer.write_u32(&self.retry)?;
-        length_written += buffer.write_u32(&self.expire)?;
-        length_written += buffer.write_u32(&self.minimum)?;
+        length_written += buffer.write_u32(self.serial)?;
+        length_written += buffer.write_u32(self.refresh)?;
+        length_written += buffer.write_u32(self.retry)?;
+        length_written += buffer.write_u32(self.expire)?;
+        length_written += buffer.write_u32(self.minimum)?;
 
         Ok(length_written)
     }
@@ -127,7 +127,7 @@ impl MxRecordData {
     }
 
     pub fn to_bytes<const T: usize>(&self, buffer: &mut PacketBuffer<T>) -> Result<usize, String> {
-        let mut length_written = buffer.write_u16(&self.preference)?;
+        let mut length_written = buffer.write_u16(self.preference)?;
         length_written += self.exchange.to_bytes(buffer)?;
 
         Ok(length_written)
@@ -177,14 +177,14 @@ pub enum DnsRecordData {
 impl DnsRecordData {
     pub fn to_bytes<const T: usize>(&self, buffer: &mut PacketBuffer<T>) -> Result<usize, String> {
         match self {
-            DnsRecordData::A(d) => return Ok(buffer.write_subarray(&d.address)?),
-            DnsRecordData::NS(d) => return Ok(d.ns_domain_name.to_bytes(buffer)?),
-            DnsRecordData::CNAME(d) => return Ok(d.c_name.to_bytes(buffer)?),
-            DnsRecordData::SOA(d) => return Ok(d.to_bytes(buffer)?),
-            DnsRecordData::PTR(d) => return Ok(d.ptr_d_name.to_bytes(buffer)?),
-            DnsRecordData::MX(d) => return Ok(d.to_bytes(buffer)?),
-            DnsRecordData::TXT(d) => return Ok(d.txt_data.to_bytes(buffer)?),
-            DnsRecordData::UNKNOWN(d) => return Ok(buffer.write_subarray(&d.0)?),
+            DnsRecordData::A(d) => Ok(buffer.write_subarray(&d.address)?),
+            DnsRecordData::NS(d) => Ok(d.ns_domain_name.to_bytes(buffer)?),
+            DnsRecordData::CNAME(d) => Ok(d.c_name.to_bytes(buffer)?),
+            DnsRecordData::SOA(d) => Ok(d.to_bytes(buffer)?),
+            DnsRecordData::PTR(d) => Ok(d.ptr_d_name.to_bytes(buffer)?),
+            DnsRecordData::MX(d) => Ok(d.to_bytes(buffer)?),
+            DnsRecordData::TXT(d) => Ok(d.txt_data.to_bytes(buffer)?),
+            DnsRecordData::UNKNOWN(d) => Ok(buffer.write_subarray(&d.0)?),
         }
     }
 }
@@ -211,8 +211,8 @@ impl DnsQuestion {
 
     pub fn to_bytes<const T: usize>(&self, buffer: &mut PacketBuffer<T>) -> Result<usize, String> {
         let mut length_written = self.name.to_bytes(buffer)?;
-        length_written += buffer.write_u16(&self.query_type.to_number())?;
-        length_written += buffer.write_u16(&self.query_class.to_number())?;
+        length_written += buffer.write_u16(self.query_type.to_number())?;
+        length_written += buffer.write_u16(self.query_class.to_number())?;
 
         Ok(length_written)
     }
@@ -261,10 +261,10 @@ impl DnsRecord {
     pub fn to_bytes<const T: usize>(&self, buffer: &mut PacketBuffer<T>) -> Result<usize, String> {
         let mut length_written = self.name.to_bytes(buffer)?;
 
-        length_written += buffer.write_u16(&self.r#type.to_number())?;
-        length_written += buffer.write_u16(&self.class.to_number())?;
-        length_written += buffer.write_u32(&self.ttl)?;
-        length_written += buffer.write_u16(&self.rd_length)?;
+        length_written += buffer.write_u16(self.r#type.to_number())?;
+        length_written += buffer.write_u16(self.class.to_number())?;
+        length_written += buffer.write_u32(self.ttl)?;
+        length_written += buffer.write_u16(self.rd_length)?;
         length_written += self.r_data.to_bytes(buffer)?;
 
         Ok(length_written)

--- a/src/protocol/string.rs
+++ b/src/protocol/string.rs
@@ -23,6 +23,10 @@ impl CharString {
         Ok(CharString { buffer: string })
     }
 
+    pub fn to_bytes<const T: usize>(&self, buffer: &mut PacketBuffer<T>) -> Result<usize, String> {
+        Ok(buffer.write_subarray(&self.buffer)?)
+    }
+
     pub fn as_buffer(&self) -> &[u8] {
         &self.buffer
     }

--- a/src/systems/dps.rs
+++ b/src/systems/dps.rs
@@ -12,7 +12,7 @@ pub struct DecisionPipelineSystem {
 
 impl DecisionPipelineSystem {
     pub async fn run(mut self) -> JoinSet<()> {
-        println!("Starting DPS...");
+        println!("[DPS] Starting DPS...");
 
         let mut join_set = JoinSet::<()>::new();
 
@@ -35,14 +35,14 @@ impl DecisionPipelineSystem {
                 // 3. Interrogate SHS
 
                 // 4. Forward query to SRS
-                println!("[DPS] SENDING QUERY TO SRS"); 
+                println!("[DPS] SENDING QUERY TO SRS");
                 if let Err(e) = self.dps_to_srs_tx.try_send(message) {
                     match e {
                         tokio::sync::mpsc::error::TrySendError::Closed(_) => {
                             panic!("DPS-SRS channel closed unexpectedly.");
                         }
                         tokio::sync::mpsc::error::TrySendError::Full(_) => {
-                            println!("DPS-SRS channel overloaded. Dropping query.");
+                            println!("[DPS] DPS-SRS channel overloaded. Dropping query.");
                         }
                     }
                 }

--- a/src/systems/dps.rs
+++ b/src/systems/dps.rs
@@ -35,6 +35,7 @@ impl DecisionPipelineSystem {
                 // 3. Interrogate SHS
 
                 // 4. Forward query to SRS
+                println!("[DPS] SENDING QUERY TO SRS"); 
                 if let Err(e) = self.dps_to_srs_tx.try_send(message) {
                     match e {
                         tokio::sync::mpsc::error::TrySendError::Closed(_) => {

--- a/src/systems/ies.rs
+++ b/src/systems/ies.rs
@@ -154,7 +154,7 @@ impl IngressEgressSystem {
 
                 // Send data to downstream client
                 if let Err(e) = downstream_socket_tx
-                    .send_to(buffer.as_slice(), received_query_state.get_origin())
+                    .send_to(buffer.to_slice(), received_query_state.get_origin())
                     .await
                 {
                     eprintln!(
@@ -203,7 +203,7 @@ impl IngressEgressSystem {
                     Ok(v) => v,
                 };
 
-                let mut parse_buf = PacketBuffer::<MAX_PACKET_SIZE>::from_raw_buffer(buffer.as_slice().to_owned());
+                let mut parse_buf = PacketBuffer::<MAX_PACKET_SIZE>::from_raw_buffer(buffer.to_slice().to_owned());
                 let test_packet = match DnsPacket::parse_from(&mut parse_buf) {
                     Err(e) => {
                         eprintln!("Error while parsing the outgoing packet. Error: {:?}", e);
@@ -228,7 +228,7 @@ impl IngressEgressSystem {
                 egress_inflight_queries.insert(horizon_id, inflight_query);
 
                 // Send via upstream_socket
-                if let Err(e) = upstream_socket_tx.send(buffer.as_slice()).await {
+                if let Err(e) = upstream_socket_tx.send(buffer.to_slice()).await {
                     eprintln!(
                         "Socket error - could not forward query to upstream resolver. Error: {e}"
                     );

--- a/src/systems/ies.rs
+++ b/src/systems/ies.rs
@@ -1,6 +1,6 @@
 use core::panic;
 use std::{
-    net::{Ipv4Addr, SocketAddr},
+    net::{IpAddr, SocketAddr},
     sync::Arc,
 };
 
@@ -19,6 +19,7 @@ use crate::{
     protocol::packet::DnsPacket, query_state::QueryState, systems::IesResolveCommand,
 };
 
+#[derive(Debug)]
 struct InflightQuery {
     original_id: u16,
     sender: oneshot::Sender<Option<DnsPacket>>,
@@ -54,7 +55,7 @@ struct InflightQuery {
 /// Listens to responses from the upstream resolver.
 pub struct IngressEgressSystem {
     socket: Arc<UdpSocket>,
-    upstream_resolver_ip: Ipv4Addr,
+    upstream_resolver_ip: IpAddr,
     ies_to_dps_tx: Sender<QueryState>,
     ies_answer_rx: Receiver<QueryState>,
     ies_upstream_resolve_rx: Receiver<HalfDuplexMessage<IesResolveCommand, Option<DnsPacket>>>,
@@ -62,7 +63,7 @@ pub struct IngressEgressSystem {
 
 impl IngressEgressSystem {
     pub async fn run(mut self) -> JoinSet<()> {
-        println!("Starting IES...");
+        println!("[IES] Starting IES...");
 
         let mut join_set = JoinSet::<()>::new();
 
@@ -79,24 +80,27 @@ impl IngressEgressSystem {
         let ingress_inflight_queries = inflight_queries.clone();
 
         if let Err(e) = upstream_socket
-            .connect(SocketAddr::new(self.upstream_resolver_ip.into(), 53))
+            .connect(SocketAddr::new(self.upstream_resolver_ip, 53))
             .await
         {
             panic!(
-                "Error while trying to connect to upstream resolver at {}. Error: {}",
+                "[IES] Error while trying to connect to upstream resolver at {}. Error: {}",
                 self.upstream_resolver_ip, e
             );
         }
 
         // CLIENT INGRESS TASK
         join_set.spawn(async move {
-            println!("Starting incoming query task...");
+            println!("[IES] Starting client ingress task...");
 
             loop {
                 let mut buf = [0_u8; MAX_PACKET_SIZE];
                 let (_, origin) = match downstream_socket_rx.recv_from(&mut buf).await {
                     Err(e) => {
-                        eprintln!("Error while receiving DGRAM: {:#?}", e);
+                        eprintln!(
+                            "[IES] CLIENT INGRESS TASK: Error while receiving DGRAM: {:#?}",
+                            e
+                        );
                         continue;
                     }
                     Ok(value) => value,
@@ -121,7 +125,7 @@ impl IngressEgressSystem {
                             panic!("DPS channel closed unexpectedly.")
                         }
                         tokio::sync::mpsc::error::TrySendError::Full(_) => {
-                            println!("IES-DPS channel overloaded. Dropping query")
+                            println!("[IES] IES-DPS channel overloaded. Dropping query")
                         }
                     }
                 }
@@ -131,22 +135,22 @@ impl IngressEgressSystem {
         // CLIENT EGRESS TASK
         // This task receives answered query states and sends them back to the querying client.
         join_set.spawn(async move {
-            println!("Starting answer task...");
+            println!("[IES] Starting client egress task...");
             loop {
                 let received_query_state = match self.ies_answer_rx.recv().await {
                     None => {
-                        panic!("IES RX channel to receive answered queries closed unexpectedly.")
+                        panic!("[IES] CLIENT EGRESS TASK: IES RX channel to receive answered queries closed unexpectedly.")
                     }
                     Some(v) => v,
                 };
 
-                println!("[IES]  RECEIVED ANSWER -> SENDING TO CLIENT");
+                println!("[IES] RECEIVED ANSWER -> SENDING TO CLIENT");
 
                 // Translate the DnsPacket into bytes
                 let mut buffer = PacketBuffer::<MAX_PACKET_SIZE>::new();
                 let bytes = match received_query_state.get_packet().to_bytes(&mut buffer) {
                     Err(e) => {
-                        eprintln!("Error while translating query to bytes: {}", e);
+                        eprintln!("[IES] CLIENT EGRESS TASK: Error while translating query to bytes: {}", e);
                         continue;
                     }
                     Ok(v) => v.to_be_bytes(),
@@ -158,7 +162,7 @@ impl IngressEgressSystem {
                     .await
                 {
                     eprintln!(
-                        "Error {e} occurred while trying to send answer to client. Dropping query"
+                        "[IES] CLIENT EGRESS TASK: Error {e} occurred while trying to send answer to client. Dropping query"
                     );
                 }
             }
@@ -167,8 +171,9 @@ impl IngressEgressSystem {
         // UPSTREAM EGRESS TASK
         // This task handles the query forwarding to an upstream resolver.
         join_set.spawn(async move {
-            println!("Starting upstream forward task...");
-            loop {
+            println!("[IES] Starting upstream egress task...");
+            println!("[IES] Connected to {:#?}", upstream_socket_tx.peer_addr());
+            'outer: loop {
                 let mut message = match self.ies_upstream_resolve_rx.recv().await {
                     None => {
                         panic!("IES-SRS resolving channel closed unexpectedly.");
@@ -176,78 +181,74 @@ impl IngressEgressSystem {
                     Some(v) => v,
                 };
 
-                println!("[IES - UPSTREAM EGRESS] RECEIVED FORWARD QUERY FROM SRS -> forwarding");
+                println!("[IES] UPSTREAM EGRESS TASK: RECEIVED FORWARD QUERY FROM SRS -> forwarding");
 
                 // Replace query ID
                 let original_id = message.payload.packet.header.id;
                 let horizon_id = Self::generate_id();
                 message.payload.packet.header.id = horizon_id;
+                println!("[IES] UPSTREAM EGRESS TASK: Replaced query ID. Old: {original_id}, New: {horizon_id}");
+
 
                 // Create InflightQuery
                 let inflight_query = InflightQuery {
                     original_id,
                     sender: message.return_channel,
                 };
+                println!("[IES] UPSTREAM EGRESS TASK: Created InflightQuery struct");
 
 
                 // Translate packet into bytes
+                println!("[IES] UPSTREAM EGRESS TASK: Translating to bytes...");
                 let mut buffer = PacketBuffer::<MAX_PACKET_SIZE>::new();
-                let _bytes = match message.payload.packet.to_bytes(&mut buffer) {
+                let length = match message.payload.packet.to_bytes(&mut buffer) {
                     Err(e) => {
-                        eprintln!("Error while translating query for upstream resolver. Error: {}", e);
+                        eprintln!("[IES] UPSTREAM EGRESS TASK: Error while translating query for upstream resolver. Error: {}", e);
                         if inflight_query.sender.send(None).is_err() {
-                            eprintln!("[IES] Could not notify SRS of above failure due failure in the return channel.");
+                            eprintln!("[IES] UPSTREAM EGRESS TASK: Could not notify SRS of above failure due failure in the return channel.");
                         }
                         continue;
                     }
                     Ok(v) => v,
                 };
 
-                let mut parse_buf = PacketBuffer::<MAX_PACKET_SIZE>::from_raw_buffer(buffer.to_slice().to_owned());
-                let test_packet = match DnsPacket::parse_from(&mut parse_buf) {
-                    Err(e) => {
-                        eprintln!("Error while parsing the outgoing packet. Error: {:?}", e);
-                        continue;
-                    }
-                    Ok(packet) => packet,
-                };
-
-                println!("");
-                println!("---------------------");
-                println!("{:#?}", message.payload.packet);
-                println!("---------------------");
-                println!("");
-
-                println!("");
-                println!("---------------------");
-                println!("{:#?}", test_packet);
-                println!("---------------------");
-                println!("");
+                let mut bytes = Vec::<u8>::with_capacity(length);
+                let buffer_slice = buffer.to_slice();
+                for i in 0..length {
+                    match buffer_slice.get(i) {
+                        None => continue 'outer,
+                        Some(v) => bytes.push(*v),
+                    };
+                }
+                println!("[IES] UPSTREAM EGRESS TASK: Translated to bytes");
 
                 // Register query as being inflight
                 egress_inflight_queries.insert(horizon_id, inflight_query);
+                println!("[IES] UPSTREAM EGRESS TASK: Registered query as inflight");
 
                 // Send via upstream_socket
-                if let Err(e) = upstream_socket_tx.send(buffer.to_slice()).await {
+                if let Err(e) = upstream_socket_tx.send(&bytes).await {
                     eprintln!(
-                        "Socket error - could not forward query to upstream resolver. Error: {e}"
+                        "[IES] UPSTREAM EGRESS TASK: Socket error - could not forward query to upstream resolver. Error: {e}"
                     );
 
                     if let Some((_, removed_query)) = egress_inflight_queries.remove(&horizon_id) {
                         let send_result = removed_query.sender.send(None);
                         if send_result.is_err() {
-                            eprintln!("Failed to notify SRS of above failure.");
+                            eprintln!("[IES] UPSTREAM EGRESS TASK: Failed to notify SRS of above failure.");
                         }
                     }
                     continue;
                 }
+                println!("[IES] UPSTREAM EGRESS TASK: Successfully sent query to upstream");
 
                 // Let the task sleep until the query's timeout is elapsed - once woken up, remove the task from the `InflightQuery` map, thereby effectively dropping the query
                 tokio::time::sleep(message.payload.timeout).await;
+                println!("[IES] UPSTREAM EGRESS TASK: Upstream Query timed out");
                 if let Some((_, removed_query)) = egress_inflight_queries.remove(&horizon_id) {
                    let send_result = removed_query.sender.send(None);
                     if send_result.is_err() {
-                        eprintln!("Failed to notify SRS that query timed out.");
+                        eprintln!("[IES] UPSTREAM EGRESS TASK: Failed to notify SRS that query timed out.");
                     }
                 }
             }
@@ -256,29 +257,30 @@ impl IngressEgressSystem {
         // UPSTREAM INGRESS TASK
         // This task handles receiving data from the upstream resolver and forwards it to the SRS.
         join_set.spawn(async move {
+            println!("[IES] Starting IES Upstream Ingress Task...");
             loop {
                 // Receive data from upstream
                 let mut buf = [0_u8; MAX_PACKET_SIZE];
                 match upstream_socket_rx.recv(&mut buf).await {
                     Err(e) => {
-                        eprintln!("Error while receiving upstream response: {e}");
+                        eprintln!("[IES] UPSTREAM INGRESS TASK: Error while receiving upstream response: {e}");
                         continue;
                     }
                     Ok(size) => {
                         if size > MAX_PACKET_SIZE {
-                            eprintln!("Max packet size exceeded. Dropping...");
+                            eprintln!("[IES] UPSTREAM INGRESS TASK: Max packet size exceeded. Dropping...");
                             continue;
                         }
                     }
                 };
 
-                println!("[IES] RECEIVED UPSTREAM ANSWER -> SENDING TO SRS");
+                println!("[IES] UPSTREAM INGRESS TASK: RECEIVED UPSTREAM ANSWER -> SENDING TO SRS");
 
                 // Parse upstream data
                 let mut packet_buf = PacketBuffer::from_raw_buffer(buf);
                 let mut packet = match DnsPacket::parse_from(&mut packet_buf) {
                     Err(_) => {
-                        eprintln!("Error while parsing received packet. Dropping...");
+                        eprintln!("[IES] UPSTREAM INGRESS TASK: Error while parsing received packet. Dropping...");
                         continue;
                     }
                     Ok(packet) => packet,
@@ -293,7 +295,7 @@ impl IngressEgressSystem {
 
                     if inflight_query.sender.send(Some(packet)).is_err() {
                         eprintln!(
-                            "Return channel failure - could not send response to SRS. Dropping..."
+                            "[IES] UPSTREAM INGRESS TASK: Return channel failure - could not send response to SRS. Dropping..."
                         );
                         continue;
                     }
@@ -305,7 +307,7 @@ impl IngressEgressSystem {
     }
 
     pub async fn new(
-        upstream_resolver_ip: Ipv4Addr,
+        upstream_resolver_ip: IpAddr,
         ies_to_dps_tx: Sender<QueryState>,
         ies_answer_rx: Receiver<QueryState>,
         ies_upstream_resolve_rx: Receiver<HalfDuplexMessage<IesResolveCommand, Option<DnsPacket>>>,

--- a/src/systems/ies.rs
+++ b/src/systems/ies.rs
@@ -15,7 +15,7 @@ use tokio::{
 };
 
 use crate::{
-    IP_ADDR, MAX_PACKET_SIZE, buffer::PacketBuffer, isc::HalfDuplexMessage,
+    MAX_PACKET_SIZE, OWN_IP_SOCKET_ADDR, buffer::PacketBuffer, isc::HalfDuplexMessage,
     protocol::packet::DnsPacket, query_state::QueryState, systems::IesResolveCommand,
 };
 
@@ -24,6 +24,34 @@ struct InflightQuery {
     sender: oneshot::Sender<Option<DnsPacket>>,
 }
 
+/// # Ingress and Egress System
+/// The **Ingress and Egress System**, **IES** for short, is the interface between the service and any external network instances related to the DNS protocol.
+/// It owns all network sockets related to DNS specific operations, parses incoming DNS packets into a [`crate::protocol::packet::DnsPacket`] wraps it in a
+/// [`crate::query_state::QueryState`].
+///
+/// ## Area of Responsibility
+/// The IES acts as the network manager and translator between the raw DNS protocol and service specific data structures.
+/// It does **not** concern itself with business logic such as mapping upstream responses to upstream queries.
+///
+/// ## Tasks
+/// The IES is made up of four tasks:
+///
+/// - Client Ingress Task
+/// - Client Egress Task
+/// - Upstream Egress Task
+/// - Upstream Ingress Task
+///
+/// ### Client Ingress Task
+/// Listens for queries from network hosts. This is the entry of a DNS query into the service.
+///
+/// ### Client Egress Task
+/// Sends responses to queries to the respective client. The is the exit of the DNS query out of the service.
+///
+/// ### Upstream Egress Task
+/// Sends a query to an upstream resolver (like Cloudflare 1.1.1.1 or Google 8.8.8.8).
+///
+/// ### Upstream Ingress Task
+/// Listens to responses from the upstream resolver.
 pub struct IngressEgressSystem {
     socket: Arc<UdpSocket>,
     upstream_resolver_ip: Ipv4Addr,
@@ -38,8 +66,8 @@ impl IngressEgressSystem {
 
         let mut join_set = JoinSet::<()>::new();
 
-        let socket_ingress_clone = self.socket.clone();
-        let socket_egress_clone = self.socket.clone();
+        let downstream_socket_tx = self.socket.clone();
+        let downstream_socket_rx = self.socket.clone();
 
         let upstream_socket = Arc::new(UdpSocket::bind("0.0.0.0:0").await.unwrap());
 
@@ -60,13 +88,13 @@ impl IngressEgressSystem {
             );
         }
 
-        // This task handles all incoming queries.
+        // CLIENT INGRESS TASK
         join_set.spawn(async move {
             println!("Starting incoming query task...");
 
             loop {
                 let mut buf = [0_u8; MAX_PACKET_SIZE];
-                let (_, origin) = match socket_ingress_clone.recv_from(&mut buf).await {
+                let (_, origin) = match downstream_socket_rx.recv_from(&mut buf).await {
                     Err(e) => {
                         eprintln!("Error while receiving DGRAM: {:#?}", e);
                         continue;
@@ -100,6 +128,7 @@ impl IngressEgressSystem {
             }
         });
 
+        // CLIENT EGRESS TASK
         // This task receives answered query states and sends them back to the querying client.
         join_set.spawn(async move {
             println!("Starting answer task...");
@@ -114,17 +143,18 @@ impl IngressEgressSystem {
                 println!("[IES]  RECEIVED ANSWER -> SENDING TO CLIENT");
 
                 // Translate the DnsPacket into bytes
-                let bytes = match received_query_state.get_packet().to_raw_bytes() {
-                    None => {
-                        eprintln!("Error while translating query to bytes.");
+                let mut buffer = PacketBuffer::<MAX_PACKET_SIZE>::new();
+                let bytes = match received_query_state.get_packet().to_bytes(&mut buffer) {
+                    Err(e) => {
+                        eprintln!("Error while translating query to bytes: {}", e);
                         continue;
                     }
-                    Some(v) => v,
+                    Ok(v) => v.to_be_bytes(),
                 };
 
                 // Send data to downstream client
-                if let Err(e) = socket_egress_clone
-                    .send_to(&bytes, received_query_state.get_origin())
+                if let Err(e) = downstream_socket_tx
+                    .send_to(buffer.as_slice(), received_query_state.get_origin())
                     .await
                 {
                     eprintln!(
@@ -134,6 +164,7 @@ impl IngressEgressSystem {
             }
         });
 
+        // UPSTREAM EGRESS TASK
         // This task handles the query forwarding to an upstream resolver.
         join_set.spawn(async move {
             println!("Starting upstream forward task...");
@@ -145,56 +176,84 @@ impl IngressEgressSystem {
                     Some(v) => v,
                 };
 
-                println!("[IES] RECEIVED FORWARD QUERY FROM SRS -> forwarding");
-
-                // Translate packet into bytes
-                let bytes = match message.payload.packet.to_raw_bytes() {
-                    None => {
-                        eprintln!("Error while translating query for upstream resolver.");
-                        if message.return_channel.send(None).is_err() {
-                            eprintln!("[IES] Could not notify SRS of above failure due failure in the return channel.");
-                        }
-                        continue;
-                    }
-                    Some(v) => v,
-                };
+                println!("[IES - UPSTREAM EGRESS] RECEIVED FORWARD QUERY FROM SRS -> forwarding");
 
                 // Replace query ID
                 let original_id = message.payload.packet.header.id;
-                let new_id = Self::generate_id();
-                message.payload.packet.header.id = new_id;
+                let horizon_id = Self::generate_id();
+                message.payload.packet.header.id = horizon_id;
 
-                // Store ID mapping
+                // Create InflightQuery
                 let inflight_query = InflightQuery {
                     original_id,
                     sender: message.return_channel,
                 };
 
-                egress_inflight_queries.insert(new_id, inflight_query);
 
-                // Send via upstream_socket and forget
-                if let Err(e) = upstream_socket_tx.send(&bytes).await {
+                // Translate packet into bytes
+                let mut buffer = PacketBuffer::<MAX_PACKET_SIZE>::new();
+                let _bytes = match message.payload.packet.to_bytes(&mut buffer) {
+                    Err(e) => {
+                        eprintln!("Error while translating query for upstream resolver. Error: {}", e);
+                        if inflight_query.sender.send(None).is_err() {
+                            eprintln!("[IES] Could not notify SRS of above failure due failure in the return channel.");
+                        }
+                        continue;
+                    }
+                    Ok(v) => v,
+                };
+
+                let mut parse_buf = PacketBuffer::<MAX_PACKET_SIZE>::from_raw_buffer(buffer.as_slice().to_owned());
+                let test_packet = match DnsPacket::parse_from(&mut parse_buf) {
+                    Err(e) => {
+                        eprintln!("Error while parsing the outgoing packet. Error: {:?}", e);
+                        continue;
+                    }
+                    Ok(packet) => packet,
+                };
+
+                println!("");
+                println!("---------------------");
+                println!("{:#?}", message.payload.packet);
+                println!("---------------------");
+                println!("");
+
+                println!("");
+                println!("---------------------");
+                println!("{:#?}", test_packet);
+                println!("---------------------");
+                println!("");
+
+                // Register query as being inflight
+                egress_inflight_queries.insert(horizon_id, inflight_query);
+
+                // Send via upstream_socket
+                if let Err(e) = upstream_socket_tx.send(buffer.as_slice()).await {
                     eprintln!(
                         "Socket error - could not forward query to upstream resolver. Error: {e}"
                     );
 
-                    match egress_inflight_queries.remove(&new_id) {
-                        None => (),
-                        Some((_, removed_query)) => {
-                            let send_result = removed_query.sender.send(None);
-                            if send_result.is_err() {
-                                eprintln!("Failed to notify SRS.");
-                            }
+                    if let Some((_, removed_query)) = egress_inflight_queries.remove(&horizon_id) {
+                        let send_result = removed_query.sender.send(None);
+                        if send_result.is_err() {
+                            eprintln!("Failed to notify SRS of above failure.");
                         }
                     }
                     continue;
                 }
 
+                // Let the task sleep until the query's timeout is elapsed - once woken up, remove the task from the `InflightQuery` map, thereby effectively dropping the query
                 tokio::time::sleep(message.payload.timeout).await;
-                egress_inflight_queries.remove(&new_id);
+                if let Some((_, removed_query)) = egress_inflight_queries.remove(&horizon_id) {
+                   let send_result = removed_query.sender.send(None);
+                    if send_result.is_err() {
+                        eprintln!("Failed to notify SRS that query timed out.");
+                    }
+                }
             }
         });
 
+        // UPSTREAM INGRESS TASK
         // This task handles receiving data from the upstream resolver and forwards it to the SRS.
         join_set.spawn(async move {
             loop {
@@ -210,7 +269,7 @@ impl IngressEgressSystem {
                             eprintln!("Max packet size exceeded. Dropping...");
                             continue;
                         }
-                    },
+                    }
                 };
 
                 println!("[IES] RECEIVED UPSTREAM ANSWER -> SENDING TO SRS");
@@ -226,18 +285,16 @@ impl IngressEgressSystem {
                 };
 
                 // Check if upstream response answers an inflight query and send it to the SRS if successful
-                match ingress_inflight_queries.remove(&packet.header.id) {
-                    Some((_, inflight_query)) => {
+                if let Some((_, inflight_query)) =
+                    ingress_inflight_queries.remove(&packet.header.id)
+                {
+                    // Replace ID with original ID
+                    packet.header.id = inflight_query.original_id;
 
-                        // Replace ID with original ID
-                        packet.header.id = inflight_query.original_id;
-
-                        if inflight_query.sender.send(Some(packet)).is_err() {
-                            eprintln!("Return channel failure - could not send response to SRS. Dropping...");
-                            continue;
-                        }
-                    }
-                    None => {
+                    if inflight_query.sender.send(Some(packet)).is_err() {
+                        eprintln!(
+                            "Return channel failure - could not send response to SRS. Dropping..."
+                        );
                         continue;
                     }
                 }
@@ -253,7 +310,7 @@ impl IngressEgressSystem {
         ies_answer_rx: Receiver<QueryState>,
         ies_upstream_resolve_rx: Receiver<HalfDuplexMessage<IesResolveCommand, Option<DnsPacket>>>,
     ) -> Self {
-        let socket = Arc::new(UdpSocket::bind(IP_ADDR).await.unwrap());
+        let socket = Arc::new(UdpSocket::bind(OWN_IP_SOCKET_ADDR).await.unwrap());
         Self {
             socket,
             upstream_resolver_ip,

--- a/src/systems/srs.rs
+++ b/src/systems/srs.rs
@@ -8,7 +8,9 @@ use tokio::{
     task::JoinSet,
 };
 
-use crate::{isc::HalfDuplexMessage, protocol::packet::DnsPacket, query_state::QueryState};
+use crate::{
+    buffer::PacketBuffer, isc::HalfDuplexMessage, protocol::{DnsHeader, packet::DnsPacket}, query_state::QueryState,
+};
 
 /// An IES Resolve Command is sent to the IES to forward a packet to the specified resolver.
 ///
@@ -43,7 +45,7 @@ impl StubResolverSystem {
 
                 let ies_command = IesResolveCommand {
                     packet: query_state.get_packet().clone(),
-                    timeout: Duration::from_secs(2),
+                    timeout: Duration::from_secs(10),
                 };
 
                 let ies_message = HalfDuplexMessage {
@@ -52,6 +54,7 @@ impl StubResolverSystem {
                 };
 
                 // Send `DnsPacket` to IES to forward it to the upstream resolver
+                println!("[SRS] SENDING QUERY TO IES UPSTREAM EGRESS TASK");
                 if let Err(e) = self.upstream_resolver_tx.try_send(ies_message) {
                     match e {
                         tokio::sync::mpsc::error::TrySendError::Closed(_) => {
@@ -67,7 +70,7 @@ impl StubResolverSystem {
                 // Await response from the IES with the resolved
                 let resolved_packet = match return_channel_rx.await {
                     Err(e) => {
-                        eprintln!("IES->SRS return channel closed before sending a message. Error: {e}");
+                        eprintln!("[SRS] IES->SRS return channel closed before sending a message. Error: {e}");
                         return;
                     }
                     Ok(packet) => match packet {

--- a/src/systems/srs.rs
+++ b/src/systems/srs.rs
@@ -61,7 +61,7 @@ impl StubResolverSystem {
                             panic!("IES Upstream Resolver channel closed unexpectedly.")
                         }
                         tokio::sync::mpsc::error::TrySendError::Full(_) => {
-                            eprintln!("IES Upstream Resolver channel overloaded. Dropping...");
+                            eprintln!("[SRS] IES Upstream Resolver channel overloaded. Dropping...");
                             return;
                         }
                     }
@@ -75,7 +75,7 @@ impl StubResolverSystem {
                     }
                     Ok(packet) => match packet {
                         None => {
-                            println!("IES was unable to resolve query. Dropping.");
+                            println!("[SRS] IES was unable to resolve query. Dropping.");
                             return;
                         }
                         Some(packet) => packet,
@@ -94,7 +94,7 @@ impl StubResolverSystem {
                             panic!("IES Answer channel closed unexpectedly.");
                         }
                         tokio::sync::mpsc::error::TrySendError::Full(_) => {
-                            eprintln!("IES answer channel overloaded. Dropping.");
+                            eprintln!("[SRS] IES answer channel overloaded. Dropping.");
                             return;
                         }
                     }


### PR DESCRIPTION
This PR introduces translation for DnsPacket structs to raw bytes that can be sent over IP.